### PR TITLE
Including TLS Flag

### DIFF
--- a/services/car-rental-v2/src/services/mongoService.js
+++ b/services/car-rental-v2/src/services/mongoService.js
@@ -41,6 +41,7 @@ export async function getCarDataFromMongo(query, context) {
 
   if (process.env.DATABASE_CERT) {
     fs.writeFileSync("./cert.pem", process.env.DATABASE_CERT);
+    clientSettings.tls = true;
     clientSettings.tlsCAFile = "./cert.pem";
   }
 
@@ -88,6 +89,7 @@ export async function getCarInfoFromMongo(filterType, context) {
 
   if (process.env.DATABASE_CERT) {
     fs.writeFileSync("./cert.pem", process.env.DATABASE_CERT);
+    clientSettings.tls = true;
     clientSettings.tlsCAFile = "./cert.pem";
   }
 
@@ -128,6 +130,7 @@ export async function mongoReadinessCheck() {
 
   if (process.env.DATABASE_CERT) {
     fs.writeFileSync("./cert.pem", process.env.DATABASE_CERT);
+    clientSettings.tls = true;
     clientSettings.tlsCAFile = "./cert.pem";
   }
 

--- a/services/destination-v2/src/services/mongoService.js
+++ b/services/destination-v2/src/services/mongoService.js
@@ -20,6 +20,7 @@ export async function getDestinationDataFromMongo(query, context) {
 
   if (process.env.DATABASE_CERT) {
     fs.writeFileSync("./cert.pem", process.env.DATABASE_CERT);
+    clientSettings.tls = true;
     clientSettings.tlsCAFile = "./cert.pem";
   }
 
@@ -78,6 +79,7 @@ export async function mongoReadinessCheck() {
 
   if (process.env.DATABASE_CERT) {
     fs.writeFileSync("./cert.pem", process.env.DATABASE_CERT);
+    clientSettings.tls = true;
     clientSettings.tlsCAFile = "./cert.pem";
   }
 

--- a/services/hotel-v2/src/services/mongoService.js
+++ b/services/hotel-v2/src/services/mongoService.js
@@ -38,6 +38,7 @@ export async function getHotelDataFromMongo(query, context) {
 
   if (process.env.DATABASE_CERT) {
     fs.writeFileSync("./cert.pem", process.env.DATABASE_CERT);
+    clientSettings.tls = true;
     clientSettings.tlsCAFile = "./cert.pem";
   }
 
@@ -85,6 +86,7 @@ export async function getHotelInfoFromMongo(filterType, context) {
 
   if (process.env.DATABASE_CERT) {
     fs.writeFileSync("./cert.pem", process.env.DATABASE_CERT);
+    clientSettings.tls = true;
     clientSettings.tlsCAFile = "./cert.pem";
   }
 
@@ -123,6 +125,7 @@ export async function mongoReadinessCheck() {
 
   if (process.env.DATABASE_CERT) {
     fs.writeFileSync("./cert.pem", process.env.DATABASE_CERT);
+    clientSettings.tls = true;
     clientSettings.tlsCAFile = "./cert.pem";
   }
 


### PR DESCRIPTION
Including TLS Flag in the code so it isn't required in the Mongo Connection URL (like with the data gen repo) when a MongoDB certificate is present. This way the same URL can be used with both repos without adding the `&tls=true` flag